### PR TITLE
Updated Desktop Helper Sample readme, modified URLs for socket.io

### DIFF
--- a/desktop-helper-sample/README.md
+++ b/desktop-helper-sample/README.md
@@ -85,3 +85,17 @@ Once both components are launched, you should be greeted with `'Connected'` stat
 Since it's an embedded server, its worth noting that this only runs on `localhost` and only administers communication between a single instance of the helper app and the UXP plugin. By default, the websocket server runs on port `4040` and the Electron helper app is served from port `3000`.
 
 Other than connecting with one another, the two components can also pass strings of text which get reflected in their `Received data from the helper` and `Received data from UXP` sections.
+
+## Note On socket.io
+
+Currently, this sample uses `127.0.0.1` to connect to the socket server in order to work on all platforms.
+
+For Windows users, this can be changed to `localhost` with no errors.
+
+However, for Mac users, the socket connection must be changed (in both `uxp/src/index.js` and `helper/src/components/SocketContext.jsx`) to bypass the client 'polling' phase:
+
+```
+let socket = io('http://localhost:4040', { transports: ['websocket'] });
+```
+
+In order for UXP to establish a connection to the socket server through `localhost`.

--- a/desktop-helper-sample/helper/src/components/SocketContext.jsx
+++ b/desktop-helper-sample/helper/src/components/SocketContext.jsx
@@ -1,8 +1,6 @@
 import React, { createContext } from 'react';
 import io from 'socket.io-client';
 
-export const socket = io('http://localhost:4040', {
-  transports: ['websocket'],
-});
+export const socket = io('http://127.0.0.1:4040');
 
 export const SocketContext = createContext();

--- a/desktop-helper-sample/uxp/src/index.js
+++ b/desktop-helper-sample/uxp/src/index.js
@@ -13,9 +13,7 @@ entrypoints.setup({
   },
 });
 
-let socket = io('http://localhost:4040', {
-  transports: ['websocket'],
-});
+let socket = io('http://127.0.0.1:4040');
 
 // Attempt to reconnect if server isn't running
 socket.on('connect_error', () => {


### PR DESCRIPTION
**Overview**
Updated the readme to include some notes regarding connecting to socket.io through `localhost` on both Windows and Mac. Changed the default connection URL for socket.io connections to be `127.0.0.1` for ease of access across both platforms.