### PR TITLE
Addressed comments left in the JSZip and Cross-Compatible samples

### DIFF
--- a/cross-compatible-js-sample/src/index.js
+++ b/cross-compatible-js-sample/src/index.js
@@ -134,6 +134,8 @@ function createLabel(e) {
       }];
 
       selection.insertionParent.addChild(label);
+
+      label.placeInParentCoordinates({ x: label.localBounds.x, y: label.localBounds.y}, { x: 0, y: 0});
     });
   }
 }

--- a/jszip-sample/src/index.js
+++ b/jszip-sample/src/index.js
@@ -104,6 +104,8 @@ async function exportArtboards() {
     }
 
     file.write(await zip.generateAsync({ type: "arraybuffer" }));
+
+    app.showAlert(`Export complete!`);
   } catch (err) {
     logError(err);
   }
@@ -141,6 +143,8 @@ async function saveZip() {
     file.write(await tempZip.generateAsync({ type: "arraybuffer" }));
 
     document.getElementById("saveZip").disabled = false;
+
+    app.showAlert(`ZIP complete!`);
   } catch (err) {
     logError(err);
   }


### PR DESCRIPTION
This PR mainly addresses the comments left in PR #37 and #39. 

In the JSZip sample, alerts have been added to notify the user when an artboard has finished exporting and when a ZIP file has finished being created. In the Cross-Compatible sample, the issue with the text labels appearing clipped has also been fixed (they should now be placed at coordinates (0, 0) respective to the parent)