### PR TITLE
Web service manifest update for PS 23.3.0 or higher

### DIFF
--- a/web-service-call-js-sample/manifest.json
+++ b/web-service-call-js-sample/manifest.json
@@ -7,7 +7,12 @@
         "app": "PS",
         "minVersion": "23.0.0"
     }],
-    "manifestVersion": 4,
+    "manifestVersion":  5,
+    "requiredPermissions": {
+      "network": {
+        "domains": ["https://api.weather.gov/points/"]
+      }
+    },
     "entrypoints": [
         {
             "type": "panel",


### PR DESCRIPTION
Change web services plugin sample manifest version to 5, add api weather domain to "requiredPermissions"